### PR TITLE
add lodash/core support

### DIFF
--- a/deep-filter-factory.js
+++ b/deep-filter-factory.js
@@ -9,13 +9,13 @@ module.exports = function (_) {
 
   function deeplyFilters (collection, predicate, visited) {
     if (_.isObject(collection)) {
-      return _.filter(collection, predicate).concat(_.flatMap(collection, function (val) {
+      return _.filter(collection, predicate).concat(_.flatten(_.map(collection, function (val) {
         if (notYetTraversed(val, visited)) {
           return deeplyFilters(val, predicate, visited.concat(collection))
         } else {
           return []
         }
-      }))
+      })))
     } else {
       return []
     }

--- a/deep-filter-factory.js
+++ b/deep-filter-factory.js
@@ -1,0 +1,29 @@
+module.exports = function (_) {
+  return {
+    filterDeep: function filterDeep (collection, predicate) {
+      predicate = predicate || _.identity
+      collection = { parent: collection }
+      return deeplyFilters(collection, predicate, [])
+    }
+  }
+
+  function deeplyFilters (collection, predicate, visited) {
+    if (_.isObject(collection)) {
+      return _.filter(collection, predicate).concat(_.flatMap(collection, function (val) {
+        if (notYetTraversed(val, visited)) {
+          return deeplyFilters(val, predicate, visited.concat(collection))
+        } else {
+          return []
+        }
+      }))
+    } else {
+      return []
+    }
+  }
+
+  function notYetTraversed (val, visited) {
+    return !_.some(visited, function (other) {
+      return other === val
+    })
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,29 +1,4 @@
 var _ = require('lodash')
+  , deepFilterInjectLodash = require('./deep-filter-factory')
 
-module.exports = {
-  filterDeep: function filterDeep (collection, predicate) {
-    predicate = predicate || _.identity
-    collection = { parent: collection }
-    return deeplyFilters(collection, predicate, [])
-  }
-}
-
-function deeplyFilters (collection, predicate, visited) {
-  if (_.isObject(collection)) {
-    return _.filter(collection, predicate).concat(_.flatMap(collection, function (val) {
-      if (notYetTraversed(val, visited)) {
-        return deeplyFilters(val, predicate, visited.concat(collection))
-      } else {
-        return []
-      }
-    }))
-  } else {
-    return []
-  }
-}
-
-function notYetTraversed (val, visited) {
-  return !_.some(visited, function (other) {
-    return other === val
-  })
-}
+module.exports = deepFilterInjectLodash(_)

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 var _ = require('lodash')
-  , deepFilterInjectLodash = require('./deep-filter-factory')
+var deepFilterInjectLodash = require('./deep-filter-factory')
 
 module.exports = deepFilterInjectLodash(_)

--- a/index.test.js
+++ b/index.test.js
@@ -3,124 +3,21 @@ var assert = require('assert')
 var _ = require('./index')
 
 var sample
+var expected
 module.exports = {
   beforeEach: function () {
-    sample = {
-      id: 1,
-      color: 'red',
-      sub: [
-        {
-          id: 8,
-          color: 'blue',
-          sub: [
-            {
-              id: 4,
-              color: 'red',
-              sub: [
-                {
-                  id: 5,
-                  color: 'red'
-                }
-              ]
-            }
-          ]
-        },
-        {
-          id: 3,
-          color: 'red'
-        }
-      ],
-      extra: {
-        bonus: {
-          depth: {
-            id: 6,
-            color: 'red'
-          }
-        },
-        nope: {
-          id: 7,
-          color: 'yellow'
-        }
-      },
-      shallow: {
-        id: 2,
-        color: 'red'
-      },
-      shallow2: {
-        id: 9,
-        color: 'gray'
-      }
-    }
+    var pair = nestedFilteredPair()
+    sample = pair.nestedObject
+    expected = pair.filterResult
   },
   filtersStuff: function () {
     var result = _.filterDeep(sample, ['color', 'red'])
-
-    var expected = [
-      sample,
-      {
-        id: 2,
-        color: 'red'
-      },
-      {
-        id: 3,
-        color: 'red'
-      },
-      {
-        id: 4,
-        color: 'red',
-        sub: [
-          {
-            id: 5,
-            color: 'red'
-          }
-        ]
-      },
-      {
-        id: 5,
-        color: 'red'
-      },
-      {
-        id: 6,
-        color: 'red'
-      }
-    ]
     assertEquals(result, expected)
   },
   uniqVisited: function () {
     sample.loop = { uhOh: sample }
-
+    expected.push(sample)
     var result = _.filterDeep(sample, ['color', 'red'])
-
-    var expected = [
-      sample,
-      {
-        id: 2,
-        color: 'red'
-      },
-      {
-        id: 3,
-        color: 'red'
-      },
-      {
-        id: 4,
-        color: 'red',
-        sub: [
-          {
-            id: 5,
-            color: 'red'
-          }
-        ]
-      },
-      {
-        id: 5,
-        color: 'red'
-      },
-      {
-        id: 6,
-        color: 'red'
-      },
-      sample
-    ]
     assertEquals(result, expected)
   }
 }
@@ -135,5 +32,68 @@ function assertEquals (actual, expected) {
     console.error('expected:', expected)
     console.error('---------')
     throw e
+  }
+}
+
+function nestedFilteredPair () {
+  var nested = {
+    id: 1,
+    color: 'red',
+    sub: [
+      {
+        id: 8,
+        color: 'blue',
+        sub: [
+          {
+            id: 4,
+            color: 'red',
+            sub: [
+              {
+                id: 5,
+                color: 'red'
+              }
+            ]
+          }
+        ]
+      },
+      {
+        id: 3,
+        color: 'red'
+      }
+    ],
+    extra: {
+      bonus: {
+        depth: {
+          id: 6,
+          color: 'red'
+        }
+      },
+      nope: {
+        id: 7,
+        color: 'yellow'
+      }
+    },
+    shallow: {
+      id: 2,
+      color: 'red'
+    },
+    shallow2: {
+      id: 9,
+      color: 'gray'
+    }
+  }
+
+  var filtered = [
+    nested,
+    nested.shallow,
+    nested.sub[1],
+    nested.sub[0].sub[0],
+    nested.sub[0].sub[0].sub[0],
+    nested.extra.bonus.depth
+  ]
+
+  return {
+    nestedObject: nested
+  , filterResult: filtered
   }
 }

--- a/lodash-core.js
+++ b/lodash-core.js
@@ -1,0 +1,4 @@
+var _ = require('lodash/core')
+  , deepFilterInjectLodash = require('./deep-filter-factory')
+
+module.exports = deepFilterInjectLodash(_)

--- a/lodash-core.js
+++ b/lodash-core.js
@@ -1,4 +1,4 @@
 var _ = require('lodash/core')
-  , deepFilterInjectLodash = require('./deep-filter-factory')
+var deepFilterInjectLodash = require('./deep-filter-factory')
 
 module.exports = deepFilterInjectLodash(_)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "some lodash mixins for deep operations on plain objects",
   "main": "index.js",
   "scripts": {
-    "test": "teenytest *.test.js",
+    "test": "teenytest test/*test.js",
     "style": "standard",
     "ci": "npm test && npm run style"
   },

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,17 +1,17 @@
-var _ = require('../index')
+var lodash = require('../index')
 var assertEquals = require('./support/assert-equals')
 var nestedFilteredPair = require('./support/generate-nested-and-expected-filtered-object-pair')
 
 var sample
 var expected
-module.exports = {
+var tests = {
   beforeEach: function () {
     var pair = nestedFilteredPair()
     sample = pair.nestedObject
     expected = pair.filterResult
   },
   filtersStuff: function () {
-    var result = _.filterDeep(sample, ['color', 'red'])
+    var result = _.filterDeep(sample, predicate)
     assertEquals(result, expected)
   },
   uniqVisited: function () {
@@ -19,5 +19,17 @@ module.exports = {
     expected.push(sample)
     var result = _.filterDeep(sample, ['color', 'red'])
     assertEquals(result, expected)
+  }
+}
+
+var _
+var predicate
+module.exports = {
+  withLodashFull: {
+    beforeEach: function () {
+      _ = lodash
+      predicate = ['color', 'red']
+    }
+  , test: tests
   }
 }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -30,8 +30,8 @@ module.exports = {
     beforeEach: function () {
       _ = lodash
       predicate = ['color', 'red']
-    }
-  , test: tests
+    },
+    test: tests
   },
   withLodashCore: {
     beforeEach: function () {
@@ -39,7 +39,7 @@ module.exports = {
       predicate = function (object) {
         return object.color === 'red'
       }
-    }
-  , test: tests
+    },
+    test: tests
   }
 }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,4 +1,5 @@
 var lodash = require('../index')
+var lodashCore = require('../lodash-core')
 var assertEquals = require('./support/assert-equals')
 var nestedFilteredPair = require('./support/generate-nested-and-expected-filtered-object-pair')
 
@@ -29,6 +30,15 @@ module.exports = {
     beforeEach: function () {
       _ = lodash
       predicate = ['color', 'red']
+    }
+  , test: tests
+  },
+  withLodashCore: {
+    beforeEach: function () {
+      _ = lodashCore
+      predicate = function (object) {
+        return object.color === 'red'
+      }
     }
   , test: tests
   }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,0 +1,23 @@
+var _ = require('../index')
+var assertEquals = require('./support/assert-equals')
+var nestedFilteredPair = require('./support/generate-nested-and-expected-filtered-object-pair')
+
+var sample
+var expected
+module.exports = {
+  beforeEach: function () {
+    var pair = nestedFilteredPair()
+    sample = pair.nestedObject
+    expected = pair.filterResult
+  },
+  filtersStuff: function () {
+    var result = _.filterDeep(sample, ['color', 'red'])
+    assertEquals(result, expected)
+  },
+  uniqVisited: function () {
+    sample.loop = { uhOh: sample }
+    expected.push(sample)
+    var result = _.filterDeep(sample, ['color', 'red'])
+    assertEquals(result, expected)
+  }
+}

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -17,7 +17,7 @@ var tests = {
   uniqVisited: function () {
     sample.loop = { uhOh: sample }
     expected.push(sample)
-    var result = _.filterDeep(sample, ['color', 'red'])
+    var result = _.filterDeep(sample, predicate)
     assertEquals(result, expected)
   }
 }

--- a/test/support/assert-equals.js
+++ b/test/support/assert-equals.js
@@ -1,0 +1,16 @@
+var assert = require('assert')
+
+module.exports = assertEquals
+
+function assertEquals (actual, expected) {
+  try {
+    assert.deepStrictEqual(actual, expected)
+  } catch (e) {
+    console.error('Comparison failed!')
+    console.error('actual:', actual)
+    console.error('---------')
+    console.error('expected:', expected)
+    console.error('---------')
+    throw e
+  }
+}

--- a/test/support/generate-nested-and-expected-filtered-object-pair.js
+++ b/test/support/generate-nested-and-expected-filtered-object-pair.js
@@ -1,39 +1,4 @@
-var assert = require('assert')
-
-var _ = require('./index')
-
-var sample
-var expected
-module.exports = {
-  beforeEach: function () {
-    var pair = nestedFilteredPair()
-    sample = pair.nestedObject
-    expected = pair.filterResult
-  },
-  filtersStuff: function () {
-    var result = _.filterDeep(sample, ['color', 'red'])
-    assertEquals(result, expected)
-  },
-  uniqVisited: function () {
-    sample.loop = { uhOh: sample }
-    expected.push(sample)
-    var result = _.filterDeep(sample, ['color', 'red'])
-    assertEquals(result, expected)
-  }
-}
-
-function assertEquals (actual, expected) {
-  try {
-    assert.deepStrictEqual(actual, expected)
-  } catch (e) {
-    console.error('Comparison failed!')
-    console.error('actual:', actual)
-    console.error('---------')
-    console.error('expected:', expected)
-    console.error('---------')
-    throw e
-  }
-}
+module.exports = nestedFilteredPair
 
 function nestedFilteredPair () {
   var nested = {

--- a/test/support/generate-nested-and-expected-filtered-object-pair.js
+++ b/test/support/generate-nested-and-expected-filtered-object-pair.js
@@ -58,7 +58,7 @@ function nestedFilteredPair () {
   ]
 
   return {
-    nestedObject: nested
-  , filterResult: filtered
+    nestedObject: nested,
+    filterResult: filtered
   }
 }


### PR DESCRIPTION
The majority of this PR is re-arranging the tests to it could more easily test both modules `./index` and `./lodash-core`.

As far as actual production code is concerned the changes are very minor.

Internally:
- the contents of `./index` are extracted and wrapped in a function which accepts a `lodash`
- `_.flatMap(` is changed to `_.flatten(_.map(`

Externally: 
- as a node module, `require('lodash-deeper')` works exactly as before
- ***new*** now you can `require('lodash-deeper/lodash-core')` for a version which uses `lodash/core` instead of `lodash`
